### PR TITLE
feat: add indent rule to eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default [
     languageOptions: { globals: globals.browser },
     rules: {
       '@stylistic/ts/semi': ["error", "always"],
+      '@stylistic/ts/indent': ["error", "tab"],
     }
   },
   pluginJs.configs.recommended,


### PR DESCRIPTION
## 📌 Descrição
Este PR adiciona a regra de indentação ao ESLint utilizando o plugin @stylistic/eslint-plugin-ts, garantindo um padrão consistente no código do projeto.

## 🔧 Alterações realizadas
- Configurada a regra @stylistic/ts/indent no arquivo de configuração do ESLint.
- Definida a indentação por tabulação (["error", "tab"]).
- Mantida a compatibilidade com as configurações existentes no projeto.

## ✅ Como testar
1. Execute o ESLint no projeto para validar a nova regra:
`npx eslint .`
2. Verifique se há erros de indentação nos arquivos que não seguem o padrão definido.

## 📌 Motivação
Garantir que todo o código siga um padrão de indentação consistente, melhorando a legibilidade e evitando conflitos de formatação entre diferentes desenvolvedores.

## ⚠️ Observações
Caso seja necessário utilizar outro estilo de indentação (2 ou 4 espaços), pois sera obrigatório indentar o código por meio de tabulação.

fix #7