### PR TITLE
feat: adicionar regra ESLint para impedir uso de console.log

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,17 +3,17 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import stylisticTs from '@stylistic/eslint-plugin-ts';
 
-
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
   {
     plugins: {
       '@stylistic/ts': stylisticTs
     },
     languageOptions: { globals: globals.browser },
     rules: {
-      '@stylistic/ts/semi': ["error", "always"],
+      '@stylistic/ts/semi': ["error", "always"],  // Garante ponto e vírgula obrigatório
+      "no-console": ["error", { allow: ["warn", "error"] }]  // Proíbe console.log(), mas permite console.warn() e console.error()
     }
   },
   pluginJs.configs.recommended,

--- a/tests/eslint-test
+++ b/tests/eslint-test
@@ -1,0 +1,4 @@
+// Este código deve gerar um erro no ESLint devido à regra "no-console"
+console.log("Esta mensagem de log não é permitida!"); // 🚨 Isso deve gerar um erro
+console.warn("Este aviso é permitido."); // ✅ Permitido
+console.error("Este erro também é permitido."); // ✅ Permitido


### PR DESCRIPTION
Adiciona a regra no-console ao ESLint para impedir o uso de console.log(), permitindo apenas console.warn() e console.error().

Atualizado eslint.config.mjs com a nova regra.
Criado tests/eslint-test.ts para validar a regra.

#43 