### PR TITLE
feat: add no-magic-numbers rule to eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ export default [
     rules: {
       '@stylistic/ts/semi': ["error", "always"],
       '@stylistic/ts/indent': ["error", "tab"],
+      "camelcase": ["error", { "properties": "always" }],
     }
   },
   pluginJs.configs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default [
     languageOptions: { globals: globals.browser },
     rules: {
       '@stylistic/ts/semi': ["error", "always"],
+      '@stylistic/ts/indent': ["error", "tab"],
     }
   },
   pluginJs.configs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default [
       '@stylistic/ts/semi': ["error", "always"],
       '@stylistic/ts/indent': ["error", "tab"],
       "camelcase": ["error", { "properties": "always" }],
+      "no-magic-numbers": ["error", { "ignore": [0, 1, -1], "ignoreArrayIndexes": true }],
     }
   },
   pluginJs.configs.recommended,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,11 @@ app.put('/posts/:id', async (req: Request, res: Response) => {
     }
   
     try {
-        const updatedpost = await prisma.post.update({
+        const updated_post = await prisma.post.update({
             where: { id: parseInt(id) },
             data: { content }
         });
-        res.json(updatedpost);
+        res.json(updated_post);
     } catch (error) {
         console.error('Error updating post:', error);
         res.status(500).json({ error: 'Failed to update post' });


### PR DESCRIPTION
## 📌 Descrição  
Esta PR adiciona a regra [`no-magic-numbers`](https://eslint.org/docs/latest/rules/no-magic-numbers) ao arquivo de configuração do **ESLint**, garantindo que valores numéricos arbitrários não sejam utilizados diretamente no código, incentivando o uso de constantes nomeadas. 🪄

## 🎯 Motivação  
- Melhorar a legibilidade e a manutenção do código.  
- Evitar o uso de valores numéricos arbitrários ("números mágicos").  
- Incentivar o uso de constantes nomeadas para facilitar o entendimento do código.  

## ✨ Alterações  
- Adicionada a regra `no-magic-numbers` com a seguinte configuração:  

  ```json
  "no-magic-numbers": ["error", { "ignore": [0, 1, -1], "ignoreArrayIndexes": true }]
  ```
  
  - Permite o uso de `0`, `1` e `-1`, pois são comuns em loops e verificações.  
  - Permite índices numéricos em arrays (`array[0]`, `array[1]`).  
  - Testes realizados para garantir que a regra identifique corretamente números mágicos no código.  

## 🛠️ Como testar  
1. Rodar o ESLint com o comando:  

   ```sh
   npx eslint **/*.ts
   ```

2. Criar um número mágico no código, como:  

   ```typescript
   let resultado = 42 * 2;  
   ```

3. Verificar se o ESLint reporta o erro:  

   ```text 
   error  No magic number: 42  no-magic-numbers  
   ```

4. Corrigir o erro substituindo por uma constante nomeada:  

   ```typescript
   const MULTIPLICADOR = 42;  
   let resultado = MULTIPLICADOR * 2;  
   ```

## 📌 Impacto esperado  
- Nenhum impacto negativo esperado no funcionamento da aplicação.  
- Código mais organizado, legível e fácil de manter.  
- Maior clareza ao evitar números arbitrários espalhados pelo código.  

fix #38 