### PR TITLE
feat: adicionar regra ESLint para evitar sombra de variáveis (no-shadow)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,8 @@ export default [
     languageOptions: { globals: globals.browser },
     rules: {
       '@stylistic/ts/semi': ["error", "always"],  // Garante ponto e vírgula obrigatório
-      "no-console": ["error", { allow: ["warn", "error"] }]  // Proíbe console.log(), mas permite console.warn() e console.error()
+      "no-console": ["error", { allow: ["warn", "error"] }],  // Proíbe console.log(), mas permite console.warn() e console.error()
+      "no-shadow": "error"
     }
   },
   pluginJs.configs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,17 +3,17 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import stylisticTs from '@stylistic/eslint-plugin-ts';
 
-
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
   {
     plugins: {
       '@stylistic/ts': stylisticTs
     },
     languageOptions: { globals: globals.browser },
     rules: {
-      '@stylistic/ts/semi': ["error", "always"],
+      '@stylistic/ts/semi': ["error", "always"],  // Garante ponto e vírgula obrigatório
+      "no-console": ["error", { allow: ["warn", "error"] }]  // Proíbe console.log(), mas permite console.warn() e console.error()
     }
   },
   pluginJs.configs.recommended,

--- a/tests/eslint-test
+++ b/tests/eslint-test
@@ -1,0 +1,4 @@
+// Este código deve gerar um erro no ESLint devido à regra "no-console"
+console.log("Esta mensagem de log não é permitida!"); // 🚨 Isso deve gerar um erro
+console.warn("Este aviso é permitido."); // ✅ Permitido
+console.error("Este erro também é permitido."); // ✅ Permitido

--- a/tests/eslint-test-shadow
+++ b/tests/eslint-test-shadow
@@ -1,0 +1,11 @@
+// Este código deve gerar um erro no ESLint devido à regra "no-shadow"
+function exemplo() {
+    let valor = 10;
+    if (true) {
+        let valor = 20; // 🚨 Isso deve gerar um erro, pois está sombreando a variável de escopo superior
+        console.log(valor);
+    }
+    console.log(valor);
+}
+
+exemplo();


### PR DESCRIPTION
Adiciona a regra no-shadow ao ESLint para evitar variáveis com o mesmo nome de escopos superiores.

Atualizado eslint.config.mjs com a regra no-shadow.
Criado tests/eslint-test-shadow.ts para validar a regra.

#53 