### PR TITLE
feat: add no-shadow rule to eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,17 @@ export default [
     languageOptions: { globals: globals.browser },
     rules: {
       '@stylistic/ts/semi': ["error", "always"],
+<<<<<<< Updated upstream
+=======
+      "@stylistic/ts/quotes": ["error", "double"],
+      "@stylistic/ts/indent": ["error", 2],
+      "@stylistic/ts/comma-dangle": ["error", "always-multiline"],
+      "@eslint no-shadow": ["error", { "hoist": "functions" }]
+
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
     }
   },
   pluginJs.configs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,17 +14,12 @@ export default [
     languageOptions: { globals: globals.browser },
     rules: {
       '@stylistic/ts/semi': ["error", "always"],
-<<<<<<< Updated upstream
-=======
+
       "@stylistic/ts/quotes": ["error", "double"],
       "@stylistic/ts/indent": ["error", 2],
       "@stylistic/ts/comma-dangle": ["error", "always-multiline"],
-      "@eslint no-shadow": ["error", { "hoist": "functions" }]
+      "no-shadow": ["error", { "hoist": "functions" }]
 
-<<<<<<< Updated upstream
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
     }
   },
   pluginJs.configs.recommended,


### PR DESCRIPTION
Título: feat: add no-shadow rule to ESLint

Adiciona a regra `no-shadow` ao ESLint para evitar o sombreamento de variáveis.

- Converte expressões de função anônimas para declarações de função nomeadas.
- Melhora a legibilidade e aproveita o hoisting para evitar erros de escopo.
- Ajusta o código legado para seguir boas práticas recomendadas pelo ESLint.
- Garante que variáveis em escopos internos não sobrescrevam declarações externas.

![image](https://github.com/user-attachments/assets/46d817dd-9834-43dc-b38e-620a0eaf14df)


fix #38 