### PR TITLE
feat: add rule no-extra-parens

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default [
     languageOptions: { globals: globals.browser },
     rules: {
       '@stylistic/ts/semi': ["error", "always"],
+      '@stylistic/ts/no-extra-parens': ["error"],
     }
   },
   pluginJs.configs.recommended,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ app.post('/posts', async (req, res) => {
         return;
     }
 
+    const a = (5 * 9)
+
     try {
         let post = await prisma.post.create({
             data: { content }


### PR DESCRIPTION
Neste feature foi adicionado o eslint @stylistic/js/no-extra-parens: "error" no eslint.config.mjs

e feito o teste com a condição const a = (5 * 9)